### PR TITLE
Rework access to only load APC/APNI once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ taxon_list.csv
 taxonomic_updates.csv
 .DS_Store
 ignore/
+output/

--- a/R/dataset_access.R
+++ b/R/dataset_access.R
@@ -24,12 +24,10 @@
 ##' # Load the a stable version of the dataset 
 ##' dataset_access_function(version="0.0.2.9000",type = "stable")
 ##'
-
-
 dataset_access_function <- function(version=default_version(), path=NULL, 
                                     type="stable") {
   if(type=="stable"){
-    return(dataset_get(version,path))
+    return(dataset_get(version, path))
   }
   if(type=="current"){
     APC <- readr::read_csv("https://biodiversity.org.au/nsl/services/export/taxonCsv",
@@ -55,12 +53,30 @@ dataset_access_function <- function(version=default_version(), path=NULL,
                                 taxonRankSortOrder = readr::col_double(),
                                 created = readr::col_datetime(format = ""),
                                 modified = readr::col_datetime(format = "")))
-    current_list<-list(APC,APNI)  
-    names(current_list)<-c("APC", "APNI")
-    return(current_list)                      
+    current_list <- list(APC, APNI)  
+    names(current_list) <- c("APC", "APNI")
+    return(current_list)
   }
 }
 
+#' Get the default version for stable data
+#'
+#' This function returns the default version for stable data, which is used when no
+#' version is specified. The default version is "0.0.1.9000".
+#'
+#' @return A character string representing the default version for stable data.
+#' @export
+#'
+#' @examples
+#' default_version()
+#'
+#' @seealso
+#' align_taxa
+#'
+#'
+default_version <- function() {
+  "0.0.2.9000"
+}
 
 
 dataset_get <- function(version = default_version(),
@@ -69,7 +85,7 @@ dataset_get <- function(version = default_version(),
     url <- paste0("https://github.com/traitecoevo/ausflora/releases/download/",
                   version,"/apc.parquet")
     apc_hash <- contentid::register(url)
-    apc_file <- contentid::resolve(apc_hash,store=TRUE,path=path)
+    apc_file <- contentid::resolve(apc_hash, store=TRUE, path=path)
     APC <- arrow::read_parquet(apc_file)
     
     #APNI
@@ -86,3 +102,70 @@ dataset_get <- function(version = default_version(),
 }
 
 
+#' Load taxonomic resources
+#'
+#' Loads taxonomic resources into the global environment. This function accesses taxonomic data from a dataset using the provided version number or the default version. The loaded data contains two lists: APC and APNI, which contain taxonomic information about plant species in Australia. The function creates several data frames by filtering and selecting data from the loaded lists.
+#'
+#' @param version The version number of the dataset to use. Defaults to the default version.
+#' @param type XXXX
+#' @param reload A logical indicating whether to reload the dataset from the data source. Defaults to FALSE.
+#' @param filetype type of file to download. parquet or csv
+#'
+#' @return The taxonomic resources data loaded into the global environment.
+#' @export
+#'
+#' @examples
+#' load_taxonomic_resources()
+#'
+#' @importFrom dplyr filter select mutate distinct arrange
+#' @importFrom crayon red
+
+load_taxonomic_resources <-
+  function(version = default_version(),
+           type = "stable",
+           reload = FALSE,
+           filetype = "parquet") {
+
+    message("Loading resources...", appendLF = FALSE)
+    on.exit(message("...done"))
+
+    taxonomic_resources <-
+      dataset_access_function(
+        version = version,
+        path = NULL,
+        type = "stable"
+      )
+    names(taxonomic_resources) <- c("APC", "APNI")
+
+    taxonomic_resources[["genera_accepted"]] <-
+      taxonomic_resources$APC %>% dplyr::filter(taxonRank %in% c("Genus"), taxonomicStatus == "accepted")
+
+    APC_tmp <-
+      taxonomic_resources$APC %>%
+      dplyr::filter(taxonRank %in% c("Series", "Subspecies", "Species", "Forma", "Varietas")) %>%
+      dplyr::select(canonicalName, scientificName, taxonomicStatus, ID = taxonID) %>%
+      dplyr::mutate(
+        stripped_canonical = strip_names(canonicalName),
+        stripped_scientific = strip_names(scientificName)
+      ) %>%
+      dplyr::distinct()
+
+    taxonomic_resources[["APC list (accepted)"]] <-
+      APC_tmp %>% dplyr::filter(taxonomicStatus == "accepted")
+    taxonomic_resources[["APC list (known names)"]] <-
+      APC_tmp %>% dplyr::filter(taxonomicStatus != "accepted")
+
+    taxonomic_resources[["APNI names"]] <-
+      taxonomic_resources$APNI %>%
+      dplyr::filter(nameElement != "sp.") %>%
+      dplyr::select(canonicalName, scientificName, ID = scientificNameID) %>%
+      dplyr::mutate(
+        taxonomicStatus = "unplaced",
+        stripped_canonical = strip_names(canonicalName),
+        stripped_scientific = strip_names(scientificName)
+      ) %>%
+      dplyr::distinct() %>%
+      dplyr::arrange(canonicalName)
+
+    return(taxonomic_resources)
+  }

--- a/R/state_diversity.R
+++ b/R/state_diversity.R
@@ -5,10 +5,8 @@
 #' This function processes the geographic data available in the current Australian Plant Census and returns state level diversity for native, introduced and more complicated species origins.
 #'
 #'
-#' @param type_of_data A character string indicating the type of data to be used. The default is "stable".  "current" downloads the file from APC directly and remakes the calculations from the most recent version.
-#'
-#' @param version Version of the database (for the stable option only)
-#'
+#' @param resources XXX
+#' 
 #' @return A data frame with columns representing each state and rows representing each species. The values in each cell represent the origin of the species in that state.
 #'
 #' @import dplyr
@@ -19,10 +17,9 @@
 #'
 #' @export
 create_species_state_origin_matrix <-
-  function(type_of_data = "stable", version = default_version()) {
-    apc <- dataset_access_function(ver = version, type = type_of_data)
-      apc_species <-
-        dplyr::filter(apc$APC,
+  function(resources = load_taxonomic_resources()) {
+    apc_species <-
+       dplyr::filter(resources$APC,
                       taxonRank == "Species" & taxonomicStatus == "accepted")
     #seperate the states
     sep_state_data <-
@@ -107,7 +104,7 @@ create_species_state_origin_matrix <-
 #'
 #' @param state A character string indicating the Australian state or territory to calculate the diversity for. Default is "NSW". Possible values are "NSW", "NT", "Qld", "WA", "ChI", "SA", "Vic", "Tas", "ACT", "NI", "LHI", "MI", "HI", "MDI", "CoI", "CSI", and "AR".
 #' @param type_of_data A character string indicating the type of data to use for the calculation. Default is "stable". Possible values are "stable" and "current".
-#' @param ver A character string indicating the version of the data to use for the calculation in the case of "stable" source. Default is "0.0.1.9000".
+#' @param version A character string indicating the version of the data to use for the calculation in the case of "stable" source. Default is "0.0.1.9000".
 #'
 #' @return A tibble of diversity counts for the specified state or territory, including native, introduced, and more complicated species origins.
 #' The tibble has three columns: "origin" indicating the origin of the species, "state" indicating the Australian state or territory, and "num_species" indicating the number of species for that origin and state.
@@ -115,7 +112,7 @@ create_species_state_origin_matrix <-
 #' @export
 #'
 #' @examples
-#' state_diversity_counts(state = "NSW", type_of_data = "current", ver = "0.0.2.9000")
+#' state_diversity_counts(state = "NSW", type_of_data = "current", version = "0.0.2.9000")
 state_diversity_counts <- function(state = c(
     "NSW",
     "NT",
@@ -137,10 +134,9 @@ state_diversity_counts <- function(state = c(
     "AR",
     "CaI"
   ),
-  type_of_data = "stable",
-  ver = default_version()) {
+   resources = load_taxonomic_resources(version = default_version())) {
     test <-
-      create_species_state_origin_matrix(ver = ver, type_of_data = type_of_data)
+      create_species_state_origin_matrix(resources=resources)
     test2 <- test[test[[state]] != "not present", ]
     state_table <- table(test2[[state]])
     return(tibble(origin=names(state_table), state=state, num_species=state_table))
@@ -149,9 +145,8 @@ state_diversity_counts <- function(state = c(
 
 
 
-get_apc_genus_family_lookup <- function(type_of_data = "stable", ver = default_version()){
-  apc <- dataset_access_function(ver = ver, type = type_of_data)
-  apc_s<-filter(apc$APC,
+get_apc_genus_family_lookup <- function(resources=load_taxonomic_resources()){
+  apc_s<-filter(resourcesAPC,
                 taxonRank == "Species")
   tibble(genus=word(apc_s$scientificName,1,1),family=apc_s$family) %>%
     distinct() -> lu

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,7 +41,9 @@ library(ausflora)
 Generating a look-up table can be done with just one function
 
 ```{r,message=FALSE}
-create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"))
+resources <- load_taxonomic_resources()
+
+create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"), resources = resources)
 ```
 
 `create_taxonomic_update_lookup` (1) provides updates where appropiate, (2) returns same name where there is a match to an accepted name, and (3) returns nothing for names the function doesn't find a match.  The returned dataframe is designed to be  set up to call `left_join` with your dataset. 
@@ -49,19 +51,45 @@ create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "C
 This is the core functionality.  Now for some more features--to see the full taxonomic information use `full=TRUE`
 
 ```{r, message=FALSE}
-create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"), full = TRUE)
+create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"), full = TRUE, resources = resources)
 ```
 
 To make a reproducible workflow, specify the version number in your code. without this the underlying taxonomic data may change.  
 
 ```{r,message=FALSE}
-create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"), version_number = "0.0.2.9000")
+resources_0029 = load_taxonomic_resources(version = "0.0.2.9000")
+create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"), resources = resources_0029)
 ```
 
 If you've got potential misspellings in your data, turn on fuzzy matching, and a putative spelling fix will be returned.  
 
 ```{r, message=FALSE}
-create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea", "Baksia integrifolia"), fuzzy_matching = TRUE)
+create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea", "Baksia integrifolia"), fuzzy_matching = TRUE, resources = resources_0029)
 ```
 
+### How to linkt 
+
+### More detailed queires
+
+For more experenced users, run two steps in workflow...
+
+1. `align_taxa`: ...Purpose is to find best alignment with name in APC and APNI. Name may not be current 
+2. `update_taxonomy`: ... Purpose is to update taxa with most relevant current name (logic behind this)
+
+```{r}
+aligned <- align_taxa(c("Poa annua", "Abies alba"), resources = resources)
+```
+
+The update 
+```{r}
+#update_taxonomy(...)
+```
+
+Can also save as file
+
+```{r}
+aligned <- align_taxa(c("Poa annua", "Abies alba"), output = "output/taxa_alignments.csv", resources = resources)
+
+#update_taxonomy(...)
+```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To make a reproducible workflow, specify the version number in your
 code. without this the underlying taxonomic data may change.
 
 ``` r
-create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"), version_number = "0.0.2.9000")
+create_taxonomic_update_lookup(c("Banksia integrifolia", "Acacia longifolia", "Commersonia rosea"), version = "0.0.2.9000")
 #> # A tibble: 3 × 2
 #>   original_name        canonical_name      
 #>   <chr>                <chr>               

--- a/inst/extdata/species.csv
+++ b/inst/extdata/species.csv
@@ -34,7 +34,7 @@ Eragrostis setifolia
 Dichanthium fecundum
 Neptunia dimorphantha
 Aristida ingrata
-Carissa spinarum
+Carissa spinarum
 Grevillea striata
 Dichanthium sericeum subsp. sericeum
 Dinebra neesii

--- a/man/align_taxa.Rd
+++ b/man/align_taxa.Rd
@@ -10,7 +10,7 @@ align_taxa(
   fuzzy_matching = TRUE,
   max_distance_abs = 3,
   max_distance_rel = 0.2,
-  ver = default_version()
+  version = default_version()
 )
 }
 \arguments{

--- a/man/create_species_state_origin_matrix.Rd
+++ b/man/create_species_state_origin_matrix.Rd
@@ -4,10 +4,7 @@
 \alias{create_species_state_origin_matrix}
 \title{Process Geographic Data and Return State Level Species Origin and Diversity Counts}
 \usage{
-create_species_state_origin_matrix(
-  type_of_data = "stable",
-  version = default_version()
-)
+create_species_state_origin_matrix()
 }
 \arguments{
 \item{type_of_data}{A character string indicating the type of data to be used. The default is "stable".  "current" downloads the file from APC directly and remakes the calculations from the most recent version.}

--- a/man/create_taxonomic_update_lookup.Rd
+++ b/man/create_taxonomic_update_lookup.Rd
@@ -8,7 +8,7 @@ create_taxonomic_update_lookup(
   species_list,
   fuzzy_matching = FALSE,
   type = "stable",
-  version_number = default_version(),
+  version = default_version(),
   full = FALSE
 )
 }
@@ -19,7 +19,7 @@ create_taxonomic_update_lookup(
 
 \item{type}{either "stable" for a consistent version, or "current" for the leading edge version.}
 
-\item{version_number}{The version number of the dataset to use. Default is \code{"0.0.1.9000"}.}
+\item{version}{The version number of the dataset to use. Default is \code{"0.0.1.9000"}.}
 
 \item{full}{logical for whether the full lookup table is returned or just the two key columns}
 }

--- a/man/load_taxonomic_resources.Rd
+++ b/man/load_taxonomic_resources.Rd
@@ -5,7 +5,7 @@
 \title{Load taxonomic resources}
 \usage{
 load_taxonomic_resources(
-  ver = default_version(),
+  version = default_version(),
   reload = FALSE,
   filetype = "parquet"
 )

--- a/man/state_diversity_counts.Rd
+++ b/man/state_diversity_counts.Rd
@@ -8,7 +8,7 @@ state_diversity_counts(
   state = c("NSW", "NT", "Qld", "WA", "ChI", "NSW", "SA", "Vic", "Tas", "ACT", "NI",
     "LHI", "MI", "HI", "MDI", "CoI", "CSI", "AR", "CaI"),
   type_of_data = "stable",
-  ver = default_version()
+  version = default_version()
 )
 }
 \arguments{
@@ -26,5 +26,5 @@ The tibble has three columns: "origin" indicating the origin of the species, "st
 This function calculates state-level diversity for native, introduced, and more complicated species origins based on the geographic data available in the current Australian Plant Census.
 }
 \examples{
-state_diversity_counts(state = "NSW", type_of_data = "current", ver = "0.0.2.9000")
+state_diversity_counts(state = "NSW", type_of_data = "current", version = "0.0.2.9000")
 }

--- a/man/update_taxonomy.Rd
+++ b/man/update_taxonomy.Rd
@@ -4,7 +4,7 @@
 \alias{update_taxonomy}
 \title{Use APC and APNI to update taxonomy, replacing synonyms to current taxa where relevant}
 \usage{
-update_taxonomy(aligned_names, output = NULL, ver = default_version())
+update_taxonomy(aligned_names, output = NULL, version = default_version())
 }
 \arguments{
 \item{aligned_names}{A character vector of plant names to update. These names must be in the format of the

--- a/tests/testthat/test-clean_names.R
+++ b/tests/testthat/test-clean_names.R
@@ -1,37 +1,35 @@
-
+resources <- load_taxonomic_resources(version = "0.0.2.9000")
 
 test_that("align_taxa() works no fuzzy", {
   expect_equal(nrow(align_taxa(original_name=c("Dryandra preissii","Banksia acuminata"),
-                               fuzzy_matching = FALSE)),2)
+                               fuzzy_matching = FALSE, resources = resources)),2)
 })
 
 
 test_that("align_taxa() works with fuzzy", {
   expect_equal(nrow(align_taxa(original_name=c("Dryandra preissii","Banksia acuminata"),
-                               fuzzy_matching = TRUE)),2)
+                               fuzzy_matching = TRUE, resources = resources)),2)
 })
 
 test_that("align_taxa() works with longer list", {
-  species_list <- readr::read_csv(system.file("extdata", "species.csv", package = "ausflora"))
+  species_list <- readr::read_csv(system.file("extdata", "species.csv", package = "ausflora"), show_col_types = FALSE)
   expect_equal(nrow(aligned_data <- align_taxa(species_list$name,
-                               fuzzy_matching = TRUE)),199)
+                               fuzzy_matching = FALSE, resources = resources)),199)
 })
 
 
 
 test_that("update_taxonomy() works",{
-  expect_equal(nrow(update_taxonomy(aligned_names=c("Dryandra preissii","Banksia acuminata")
-                               )),2)
+  expect_equal(nrow(update_taxonomy(aligned_names=c("Dryandra preissii","Banksia acuminata"), 
+              resources = resources)),2)
 })
 
 test_that("update_taxonomy() works",{
-  expect_equal(nrow(create_taxonomic_update_lookup(c("Dryandra preissii","Banksia acuminata"))),2)
+  expect_equal(nrow(create_taxonomic_update_lookup(c("Dryandra preissii", "Banksia acuminata"), resources = resources)), 2)
 })
 
 
 test_that("state_diversity() works",{
-  nsw_species_counts<-state_diversity_counts(state = "NSW", type_of_data = "stable",ver=default_version())
+  nsw_species_counts<-state_diversity_counts(state = "NSW", resources = resources)
   expect_true(sum(nsw_species_counts$num_species)>7000 & sum(nsw_species_counts$num_species)<10000)
-  nsw_species_counts_2<-state_diversity_counts(state = "NSW", type_of_data = "current")
-  expect_true(sum(nsw_species_counts_2$num_species)>7000 & sum(nsw_species_counts_2$num_species)<10000)
 })


### PR DESCRIPTION
This PR changes the way data is loaded, to reduce the number of times dataset is loaded. This is by far the slowest part, so we want to avoid reloading if possible. 

Functions now have a default that will load the data, but also an option to pass in the data. 